### PR TITLE
Remove deprecated aural stylesheet

### DIFF
--- a/standard.css
+++ b/standard.css
@@ -296,14 +296,6 @@ body.dfnEnabled dfn { cursor: pointer; }
 .dfnPanel * + p { margin-top: 0.25em; }
 .dfnPanel li { list-style-position: inside; }
 
-@media aural {
-  h1, h2, h3 { stress: 20; richness: 90 }
-  .hide { speak: none }
-  p.copyright { volume: x-soft; speech-rate: x-fast }
-  dt { pause-before: 20% }
-  code, pre { speak-punctuation: code }
-}
-
 @media print {
   html { font-size: 8pt; }
   @page { margin: 1cm 1cm 1cm 1cm; }


### PR DESCRIPTION
Per the CSS Validator we ought not to use this.
