### PR TITLE
Optimize dfn.js

### DIFF
--- a/dfn.js
+++ b/dfn.js
@@ -6,31 +6,25 @@ var dfnMapTarget = -1;
 var dfnMapDone = false;
 var dfnMap = {};
 function initDfn() {
-  var links = [];
-  dfnMapTarget = document.links.length;
-  for (var i = 0; i < dfnMapTarget; i += 1)
-    links[i] = document.links[i];
+  var links = document.querySelectorAll('a[href*="#"]');
+  dfnMapTarget = links.length;
   var k = 0;
   var n = 0;
   var initDfnInternal = function () {
     n += 1;
     var start = new Date();
     while (k < dfnMapTarget) {
-      if (links[k].hash.length > 1) {
-        if (!links[k].closest('.no-backref, .self-link, ul.index, #idl-index + pre, ol.toc')) {
-          var s;
-          if (links[k].hasAttribute('data-x-internal'))
-            s = links[k].getAttribute('data-x-internal')
-          else
-            s = links[k].hash.substr(1);
-          if (!(s in dfnMap))
-            dfnMap[s] = [];
-          dfnMap[s].push(links[k]);
-        }
+      var s = links[k].getAttribute('href').split('#')[1];
+      if (!links[k].closest('.no-backref, .self-link, ul.index, #idl-index + pre, ol.toc')) {
+        if (links[k].hasAttribute('data-x-internal'))
+          s = links[k].getAttribute('data-x-internal')
+        if (!(s in dfnMap))
+          dfnMap[s] = [];
+        dfnMap[s].push(links[k]);
       }
       k += 1;
       if ('requestIdleCallback' in window) {
-        if (new Date() - start > 10) {
+        if (k % 1000 === 0) {
           requestIdleCallback(initDfnInternal);
           return;
         }

--- a/dfn.js
+++ b/dfn.js
@@ -14,6 +14,7 @@ function initDfn() {
     n += 1;
     var start = new Date();
     while (k < dfnMapTarget) {
+      // Don't use .href or .hash because the URL parser is relatively expensive
       var s = links[k].getAttribute('href').split('#')[1];
       if (!links[k].closest('.no-backref, .self-link, ul.index, #idl-index + pre, ol.toc')) {
         if (links[k].hasAttribute('data-x-internal'))


### PR DESCRIPTION
* 47ms was spent on creating a non-live array of document.links.
  querySelectorAll's return value is non-live already.
* 95ms was spent on .hash.substr, which I think invokes URL parser,
  serializer, and then string manipulation. Instead move the "#"
  check into the selector for querySelectorAll, and avoid invoking
  the URL parser.
* The call to .closest() is not changed but now takes 57ms instead
  of 200ms. I have no idea why.
* Avoid invoking `new Date()` 480,000 times, and instead assume
  that processing 1000 links in a single idle callback is a-ok.

All in all, the time spent in dfnInternal went down from ~750ms to
~350ms in Chrome Canary.

<img width="1658" alt="dfnjs-perf-comparison" src="https://cloud.githubusercontent.com/assets/244772/20544394/28a9df32-b10a-11e6-9ecb-3e9a6c1d9ae6.png">
