### PR TITLE
Optimize dfn.js some more

### DIFF
--- a/dfn.js
+++ b/dfn.js
@@ -15,7 +15,8 @@ function initDfn() {
     var start = new Date();
     while (k < dfnMapTarget) {
       // Don't use .href or .hash because the URL parser is relatively expensive
-      var s = links[k].getAttribute('href').split('#')[1];
+      var s = links[k].getAttribute('href');
+      s = s.substring(s.indexOf('#') + 1);
       if (!links[k].closest('.no-backref, .self-link, ul.index, #idl-index + pre, ol.toc')) {
         if (links[k].hasAttribute('data-x-internal'))
           s = links[k].getAttribute('data-x-internal')
@@ -24,15 +25,15 @@ function initDfn() {
         dfnMap[s].push(links[k]);
       }
       k += 1;
-      if ('requestIdleCallback' in window) {
-        if (k % 1000 === 0) {
-          requestIdleCallback(initDfnInternal);
-          return;
-        }
-      } else {
-        if (new Date() - start > 1000) {
-          setTimeout(initDfnInternal, 10000);
-          return;
+      if (k % 1000 === 0) {
+        if ('requestIdleCallback' in window) {
+            requestIdleCallback(initDfnInternal);
+            return;
+        } else {
+          if (new Date() - start > 500) {
+            setTimeout(initDfnInternal, 500);
+            return;
+          }
         }
       }
     }

--- a/dfn.js
+++ b/dfn.js
@@ -6,13 +6,14 @@ var dfnMapTarget = -1;
 var dfnMapDone = false;
 var dfnMap = {};
 function initDfn() {
+  var supportsIdleCallback = 'requestIdleCallback' in window;
   var links = document.querySelectorAll('a[href*="#"]');
   dfnMapTarget = links.length;
   var k = 0;
   var n = 0;
   var initDfnInternal = function () {
     n += 1;
-    var start = new Date();
+    var start = Date.now();
     while (k < dfnMapTarget) {
       // Don't use .href or .hash because the URL parser is relatively expensive
       var s = links[k].getAttribute('href');
@@ -26,11 +27,11 @@ function initDfn() {
       }
       k += 1;
       if (k % 1000 === 0) {
-        if ('requestIdleCallback' in window) {
+        if (supportsIdleCallback) {
             requestIdleCallback(initDfnInternal);
             return;
         } else {
-          if (new Date() - start > 500) {
+          if (Date.now() - start > 500) {
             setTimeout(initDfnInternal, 500);
             return;
           }


### PR DESCRIPTION
Use `substring` + `indexOf` instead of `split("#")[1]` to avoid garbage.

Avoid calling `new Date()` on every iteration when
`requestIdleCallback` is not supported. Also change the timeouts
since it seems unnecessarily long to wait 10 seconds.

This change reduces the time spent in dfnInternal from ~350ms to
~220ms in Chrome Canary, and from ~270ms to ~85ms in WebKit.