### PR TITLE
Insert file-issue link after a timeout if document.body is null

### DIFF
--- a/file-issue.js
+++ b/file-issue.js
@@ -1,10 +1,10 @@
 // Usage: include a link like `<a href="https://github.com/whatwg/{my-repo}/issues/new">file an issue</a>`, or give it
 // `id="file-issue-link"` instead. The URL can include ?title=... to give a title prefix. Then include this script with
-// `<script src="https://resources.whatwg.org/file-issue.js" async></script>`. Style the element using the selector
-// `.selected-text-file-an-issue`.
+// `<script src="https://resources.whatwg.org/file-issue.js" async></script>` after that link. Style the element using
+// the selector `.selected-text-file-an-issue`.
 //
 // If you don't have a file an issue link on your spec (e.g. for a spec split into multiple documents), you can use
-// a `data-file-issue-url=""` attribute on the `<script>` tag.
+// a `data-file-issue-url=""` attribute on the `<script>` tag, and include this script right after the `<body>` tag.
 
 (function () {
   'use strict';

--- a/file-issue.js
+++ b/file-issue.js
@@ -28,7 +28,7 @@
 
   function appendFileLink() {
     if (document.body) {
-      document.body.appendChild(fileLink);
+      document.body.insertBefore(fileLink, document.body.firstChild);
     } else {
       setTimeout(appendFileLink, 1000);
     }

--- a/file-issue.js
+++ b/file-issue.js
@@ -26,7 +26,14 @@
   fileLink.className = 'selected-text-file-an-issue';
   fileLink.textContent = 'File an issue about the selected text';
 
-  document.body.appendChild(fileLink);
+  function appendFileLink() {
+    if (document.body) {
+      document.body.appendChild(fileLink);
+    } else {
+      setTimeout(appendFileLink, 1000);
+    }
+  }
+  appendFileLink();
 
   window.addEventListener('mouseup', handleInteraction);
   window.addEventListener('keydown', handleInteraction);

--- a/file-issue.js
+++ b/file-issue.js
@@ -26,14 +26,7 @@
   fileLink.className = 'selected-text-file-an-issue';
   fileLink.textContent = 'File an issue about the selected text';
 
-  function appendFileLink() {
-    if (document.body) {
-      document.body.insertBefore(fileLink, document.body.firstChild);
-    } else {
-      setTimeout(appendFileLink, 1000);
-    }
-  }
-  appendFileLink();
+  document.body.insertBefore(fileLink, document.body.firstChild);
 
   window.addEventListener('mouseup', handleInteraction);
   window.addEventListener('keydown', handleInteraction);

--- a/file-issue.js
+++ b/file-issue.js
@@ -5,6 +5,8 @@
 //
 // If you don't have a file an issue link on your spec (e.g. for a spec split into multiple documents), you can use
 // a `data-file-issue-url=""` attribute on the `<script>` tag, and include this script right after the `<body>` tag.
+//
+// If you want to include this script in `head`, use `defer` instead of `async`.
 
 (function () {
   'use strict';


### PR DESCRIPTION
I noticed that this happens often in WebKit, and obviously it is
a race condition if the `body` element exists yet for an `async`
script in `head`.