### PR TITLE
Tweak underline style in dfnPanel

### DIFF
--- a/standard.css
+++ b/standard.css
@@ -310,6 +310,7 @@ p.copyright > span { display: inline-block; border: none; }
 
 body.dfnEnabled dfn, body.dfnEnabled h2[data-dfn-type], body.dfnEnabled h3[data-dfn-type], body.dfnEnabled h4[data-dfn-type], body.dfnEnabled h5[data-dfn-type], body.dfnEnabled h6[data-dfn-type] { cursor: pointer; }
 .dfnPanel {
+  cursor: auto;
   display: inline;
   position: absolute;
   z-index: 35;
@@ -322,7 +323,10 @@ body.dfnEnabled dfn, body.dfnEnabled h2[data-dfn-type], body.dfnEnabled h3[data-
   border: outset 0.2em;
 }
 .dfnPanel * { margin: 0; padding: 0; font: inherit; text-indent: 0; }
-.dfnPanel :link, .dfnPanel :visited { color: black; }
+.dfnPanel :link, .dfnPanel :visited { color: black; cursor: pointer; }
+/* Delicate specificity wars to pretend isolation from pre:hover rules elsewhere... */
+.dfnPanel *, pre:hover .dfnPanel * { text-decoration: none; }
+pre:hover .dfnPanel :link:hover, pre:hover .dfnPanel :visited:hover { text-decoration: underline; }
 .dfnPanel p:not(.spec-link) { font-weight: bolder; }
 .dfnPanel * + p { margin-top: 0.25em; }
 .dfnPanel li { list-style-position: inside; }


### PR DESCRIPTION
This removes the underline in the panel by default and adds it on
:hover, including in `<pre>` which earlier would underline all links
when the `<pre>` is hovered. Also change back the cursor to 'auto'
inside the panel.

Fixes #46.