### PR TITLE
Tweak styles for snapshot warning

### DIFF
--- a/bikeshed.css
+++ b/bikeshed.css
@@ -57,17 +57,17 @@ details.annoying-warning {
   border-width: 1px 1px 0 1px;
   box-shadow: 0 0 0.5em rgba(0, 0, 0, 0.5);
   color: rgba(255, 255, 255, 0.95);
-  padding: 10px 0;
   opacity: .95;
   position: fixed;
   left: 5%;
   margin: 0 auto;
   right: 5%;
-  z-index: 99;
+  z-index: 10;
 }
 
 details.annoying-warning[open] {
-  bottom: 50%;
+  top: 10%;
+  top: calc(5vw + 5vh);
   max-width: 1024px;
   outline: solid 10000px rgba(255, 255, 255, 0.6);
 }
@@ -80,21 +80,34 @@ details.annoying-warning:not([open]) {
 }
 
 details.annoying-warning > summary {
-  display: block; /* polyfill */
+  display: list-item; /* polyfill */
   font-size: 0.875em;
   font-weight: bold;
   letter-spacing: 0.02em;
-  margin-bottom: 0px;
+  padding: 10px 5px;
   text-align: center;
   text-transform: uppercase;
   text-shadow: 0px 1px 2px rgba(0, 0, 0, 0.85);
   cursor: default;
 }
 
+details.annoying-warning > summary::after {
+  content: " Expand";
+  position: absolute;
+  top: 0;
+  right: 5px;
+  font-size: smaller;
+  font-weight: bold;
+}
+
+details.annoying-warning[open] > summary::after {
+  content: " Collapse";
+}
+
 details.annoying-warning p {
-  padding: 0.25em 7.5%;
+  padding: 0 7.5% 1em;
   line-height: 1.4;
-  margin-top: 0.25em;
+  margin: 0;
   text-shadow: 0px 1px 1px rgba(0, 0, 0, 0.85);
 }
 

--- a/standard.css
+++ b/standard.css
@@ -29,7 +29,11 @@ body { margin: 0 auto; padding: 0 2.5em 2em 2.5em; max-width: 80em; background: 
   background: rgba(255, 255, 255, 0.8);
   font-size: smaller;
   padding: 4px 10px;
-  z-index: 1;
+  z-index: 4;
+}
+
+.status-LS-COMMIT .selected-text-file-an-issue {
+  bottom: 40px; /* Dodge the collapsed .annoying-warning */
 }
 
 @media (max-width: 767px) {

--- a/standard.css
+++ b/standard.css
@@ -32,7 +32,7 @@ body { margin: 0 auto; padding: 0 2.5em 2em 2.5em; max-width: 80em; background: 
   z-index: 4;
 }
 
-.status-LS-COMMIT .selected-text-file-an-issue {
+.status-LS-COMMIT .selected-text-file-an-issue, .status-LS-BRANCH .selected-text-file-an-issue {
   bottom: 40px; /* Dodge the collapsed .annoying-warning */
 }
 


### PR DESCRIPTION
Add "collapse" and "expand" label for the `<summary>` to make it clear
that it can be collapsed. Fixes https://github.com/whatwg/meta/issues/18

Also fix overlapping issues between snapshot warning, dfn panel and
the file issue link.

Also make the snapshot warning not grow upwards outside the viewport
for narrow viewports.

Also use display: list-item for `<summary>` so that the disclosure
triangle is shown in compliant UAs.