### PR TITLE
Enable cross-multipage dfn.js

### DIFF
--- a/dfn.js
+++ b/dfn.js
@@ -9,12 +9,12 @@ var dfnMap = {};
 var dfnPanel;
 var dfnTimeout;
 function dfnLoad(event) {
+  if (event.target && event.target instanceof HTMLAnchorElement) {
+    return;
+  }
   if (dfnPanel) {
     dfnPanel.parentNode.removeChild(dfnPanel);
     dfnPanel = null;
-  }
-  if (event.target && event.target instanceof HTMLAnchorElement) {
-    return;
   }
   if (!dfnMapDone) {
     document.body.classList.remove('dfnEnabled');

--- a/dfn.js
+++ b/dfn.js
@@ -18,12 +18,18 @@ function dfnLoad(event) {
   }
   if (!dfnMapDone) {
     document.body.classList.remove('dfnEnabled');
+    dfnPanel = document.createElement('div');
+    dfnPanel.className = 'dfnPanel';
+    dfnPanel.innerHTML = "Loading cross-references…";
+    dfnMovePanel(null);
     fetch('/xrefs.json')
       .then(response => response.json())
       .then(data => {
         dfnMap = data;
         dfnMapDone = true;
         document.body.classList.add('dfnEnabled');
+        dfnPanel.parentNode.removeChild(dfnPanel);
+        dfnPanel = null;
         dfnShow(event);
       })
   } else {
@@ -123,7 +129,9 @@ function dfnMovePanel(event) {
   dfnPanel.style.maxHeight = '50vh';
   dfnPanel.style.overflow = 'auto';
   document.body.appendChild(dfnPanel);
-  event.stopPropagation();
+  if (event) {
+    event.stopPropagation();
+  }
 }
 
 document.body.classList.add('dfnEnabled');


### PR DESCRIPTION
This change enables the dfn popups in multipage output to show links to all
cross-references for a <dfn> term across all files in the multipage output,
using a JSON data file generated by wattsi.

For single-page output this change replaces the existing dfn.js mechanism with
the same one used for multipage output (in the interest of not needing to
maintain separate mechanisms for single-page vs multipage for the HTML spec).

But since dfn.js is used by other specs, we can’t replace it, so we’ll neither
to either:

1. Move this multipage dfn.js to whatwg/html-build (since at this point, the
   HTML spec is the only spec we have multipage output for anyway).

2. Or, rename this dfn-multipage.js and keep it here.

In the mean time, the diff currently in this PR enables this change to be
reviewed by comparing the new code here to the code it’s replacing.

Depends on https://github.com/whatwg/wattsi/pull/46