### PR TITLE
Make the .domTree colors actually apply

### DIFF
--- a/standard.css
+++ b/standard.css
@@ -374,3 +374,4 @@ ul.domTree .t2 .value { color: blue; font-weight: normal; }
 ul.domTree .t3 code, .domTree .t4 code, .domTree .t5 code { color: gray; }
 ul.domTree .t7 code, .domTree .t8 code { color: green; }
 ul.domTree .t10 code { color: teal; }
+ul.domTree code :link, ul.domTree code :visited { color: inherit; }


### PR DESCRIPTION
Another rule sets the color to orangered for links in code, so
we need to undo that rule to have the .domTree colors show up.