### PR TITLE
Ensure black bullet/disc for dfn-popup references

### DIFF
--- a/standard.css
+++ b/standard.css
@@ -333,7 +333,7 @@ body.dfnEnabled dfn, body.dfnEnabled h2[data-dfn-type], body.dfnEnabled h3[data-
 pre:hover .dfnPanel :link:hover, pre:hover .dfnPanel :visited:hover { text-decoration: underline; }
 .dfnPanel p:not(.spec-link) { font-weight: bolder; }
 .dfnPanel * + p { margin-top: 0.25em; }
-.dfnPanel li { list-style-position: inside; }
+.dfnPanel li { list-style-position: inside; list-style-type: disc; }
 
 @media print {
   html { font-size: 8pt; }


### PR DESCRIPTION
This change ensures that when a dfn is inside a bulleted list (as for example
most every dfn in the HTML spec Dependencies section) the references displayed
in its dfn popup are shown with the normal/usual filled-black-bullet list-item
markers (top-level "disc" list-item markers in CSS terms).

Without this change, the references for a dfn that’s inside a bulleted list
end up shown with unfilled bullets (second-level "circle" markers).